### PR TITLE
[iOS] 2주차 코드리뷰 반영 (이슈레이블 제외)

### DIFF
--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -70,7 +70,7 @@ extension FilterTableViewController: UITableViewDataSource {
 
 extension FilterTableViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 44))
+        let headerView = UIView()
 
         let label: UILabel = {
             let label = UILabel()

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -18,6 +18,9 @@ class FilterTableViewController: UIViewController {
     
     private lazy var filterMenu = [status, manager, labelKind]
     
+    private let filterListCellIdentifier = "filterListCell"
+    private let filterListHeaderIdentifier = "filterListHeader"
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.dataSource = self
@@ -28,8 +31,8 @@ class FilterTableViewController: UIViewController {
     
     func tableViewLayout() {
         tableView.rowHeight = 44
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-        tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "header")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.filterListCellIdentifier)
+        tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: self.filterListHeaderIdentifier)
         
         view.addSubview(tableView)
         
@@ -55,7 +58,7 @@ extension FilterTableViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
         cell.textLabel?.text = filterMenu[indexPath.section][indexPath.row]
         let image = UIImage(systemName: "checkmark")

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -9,14 +9,14 @@ import UIKit
 
 class FilterTableViewController: UIViewController {
 
-    let tableView = UITableView()
+    private let tableView = UITableView()
     
-    let sectionKind = ["상태", "담당자", "레이블"]
-    let status = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"]
-    var manager = ["chloe", "head", "sam", "zello"]
-    var labelKind = ["레이블 없음", "그룹프로젝트:이슈트래커"]
+    private let sectionKind = ["상태", "담당자", "레이블"]
+    private let status = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"]
+    private var manager = ["chloe", "head", "sam", "zello"]
+    private var labelKind = ["레이블 없음", "그룹프로젝트:이슈트래커"]
     
-    lazy var filterMenu = [status, manager, labelKind]
+    private lazy var filterMenu = [status, manager, labelKind]
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## 🔨 작업 내용
리팩토링

- [x] 테이블뷰 헤더 중복 레이아웃 (프레임,컨스트레인트)에 프레임 삭제
- [x] 헤더와 셀의 identifier 수정 및 프로퍼티 저장
- [x] 프로퍼티의 캡슐화를 위한 private 지정

Issue Number: #64

## 🔑 핵심 키워드
* identifier
* private
* frame

## 🤔 고민했던 부분
* UIView를 생성시 프레임을 지정하는것이 당연하다 생각했지만, 없이도 생성이 된다.

## 📝 기타 설명
* 코드 외엔 달라진것이 없어 생략합니다.