### PR TITLE
[iOS] 필터뷰 상단 네비게이션바를 커스텀셀로 구현

### DIFF
--- a/iOS/Issue-tracker/Issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/Issue-tracker/Issue-tracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		DB902B772A16AF0F0007BEB9 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB902B762A16AF0F0007BEB9 /* UIFont+Extension.swift */; };
 		DB902B832A16BF540007BEB9 /* FilterTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */; };
 		DBCF80F72A11D1F8008BED58 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCF80F62A11D1F5008BED58 /* UIColor+Extension.swift */; };
+		DBFACA962A1F1AA800D60438 /* CustomNaviFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */; };
 		E05346E5DBC8E9DFC642EE57 /* Pods_Issue_tracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B94F74D84E2128C77C308753 /* Pods_Issue_tracker.framework */; };
 /* End PBXBuildFile section */
 
@@ -50,6 +51,7 @@
 		DB902B762A16AF0F0007BEB9 /* UIFont+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTableViewController.swift; sourceTree = "<group>"; };
 		DBCF80F62A11D1F5008BED58 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNaviFilter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */,
+				DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */,
 			);
 			path = FilterIssueTable;
 			sourceTree = "<group>";
@@ -305,6 +308,7 @@
 			files = (
 				DB902B832A16BF540007BEB9 /* FilterTableViewController.swift in Sources */,
 				DBCF80F72A11D1F8008BED58 /* UIColor+Extension.swift in Sources */,
+				DBFACA962A1F1AA800D60438 /* CustomNaviFilter.swift in Sources */,
 				DB44ABF62A0CA8C9004F3353 /* TabBarViewController.swift in Sources */,
 				DB4C5B912A0B82EC0064C242 /* AppDelegate.swift in Sources */,
 				DB902B752A16AEE80007BEB9 /* IssueCell.swift in Sources */,

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -8,13 +8,12 @@
 import UIKit
 
 class CustomNaviFilter: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
-
+    
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("< 취소", for: .normal)
+        button.setTitleColor(UIColor(red: 0, green: 122/255, blue: 255/255, alpha: 1), for: .normal)
+        button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
+        return button
+    }()
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -31,4 +31,6 @@ class CustomNaviFilter: UIView {
         label.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
         return label
     }()
+    
+    lazy var component = [self.cancelButton, self.filterLabel, self.saveButton]
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -24,4 +24,11 @@ class CustomNaviFilter: UIView {
         button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
         return button
     }()
+    
+    private lazy var filterLabel: UILabel = {
+        let label = UILabel()
+        label.text = "필터"
+        label.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
+        return label
+    }()
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -16,4 +16,12 @@ class CustomNaviFilter: UIView {
         button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
         return button
     }()
+    
+    private lazy var saveButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("저장", for: .normal)
+        button.setTitleColor(UIColor(red: 0, green: 122/255, blue: 255/255, alpha: 1), for: .normal)
+        button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
+        return button
+    }()
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -1,12 +1,19 @@
 import UIKit
 
+protocol CustomNaviDelegate: AnyObject {
+    func cancelButtonTapped()
+    func saveButtonTapped()
+}
+
 class CustomNaviFilter: UIView {
+    weak var delegate: CustomNaviDelegate?
     
     private lazy var cancelButton: UIButton = {
         let button = UIButton()
         button.setTitle("< 취소", for: .normal)
         button.setTitleColor(UIColor(red: 0, green: 122/255, blue: 255/255, alpha: 1), for: .normal)
         button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
+        button.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
         return button
     }()
     
@@ -15,6 +22,7 @@ class CustomNaviFilter: UIView {
         button.setTitle("저장", for: .normal)
         button.setTitleColor(UIColor(red: 0, green: 122/255, blue: 255/255, alpha: 1), for: .normal)
         button.titleLabel?.font = UIFont(name: "SFProDisplay-Semibold", size: 18)
+        button.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
         return button
     }()
     
@@ -49,8 +57,16 @@ class CustomNaviFilter: UIView {
             filterLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             filterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -17)
         ])
-        
     }
+    
+    @objc func cancelButtonTapped(){
+        delegate?.cancelButtonTapped()
+    }
+    
+    @objc func saveButtonTapped(){
+        delegate?.saveButtonTapped()
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -1,10 +1,3 @@
-//
-//  CustomNaviFilter.swift
-//  Issue-tracker
-//
-//  Created by leehwajin on 2023/05/25.
-//
-
 import UIKit
 
 class CustomNaviFilter: UIView {
@@ -37,6 +30,7 @@ class CustomNaviFilter: UIView {
     override init(frame: CGRect) {
         super .init(frame: frame)
         self.backgroundColor = UIColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1.0)
+        layout()
     }
     
     func layout() {
@@ -55,9 +49,10 @@ class CustomNaviFilter: UIView {
             filterLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             filterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -17)
         ])
+        
     }
-    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -33,4 +33,31 @@ class CustomNaviFilter: UIView {
     }()
     
     lazy var component = [self.cancelButton, self.filterLabel, self.saveButton]
+    
+    override init(frame: CGRect) {
+        super .init(frame: frame)
+        self.backgroundColor = UIColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1.0)
+    }
+    
+    func layout() {
+        for item in component {
+            self.addSubview(item)
+            item.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            cancelButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            
+            saveButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            saveButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            
+            filterLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            filterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -17)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNaviFilter.swift
@@ -1,0 +1,20 @@
+//
+//  CustomNaviFilter.swift
+//  Issue-tracker
+//
+//  Created by leehwajin on 2023/05/25.
+//
+
+import UIKit
+
+class CustomNaviFilter: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 class FilterTableViewController: UIViewController {
-
-    private let tableView = UITableView()
+    
     private let customView = CustomNaviFilter()
+    private let tableView = UITableView()
     
     private let sectionKind = ["상태", "담당자", "레이블"]
     private let status = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"]
@@ -26,8 +26,22 @@ class FilterTableViewController: UIViewController {
         super.viewDidLoad()
         tableView.dataSource = self
         tableView.delegate = self
-
+        customViewLayout()
         tableViewLayout()
+    }
+    
+    func customViewLayout() {
+        
+        view.addSubview(customView)
+        
+        customView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            customView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
+            customView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            customView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            customView.heightAnchor.constraint(equalToConstant: 70)
+        ])
     }
     
     func tableViewLayout() {
@@ -40,7 +54,7 @@ class FilterTableViewController: UIViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
+            tableView.topAnchor.constraint(equalTo: customView.bottomAnchor, constant: 0),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0)
@@ -49,30 +63,30 @@ class FilterTableViewController: UIViewController {
 }
 
 extension FilterTableViewController: UITableViewDataSource {
-
+    
     func numberOfSections(in tableView: UITableView) -> Int {
-    return sectionKind.count
+        return sectionKind.count
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return filterMenu[section].count
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
         cell.textLabel?.text = filterMenu[indexPath.section][indexPath.row]
         let image = UIImage(systemName: "checkmark")
         cell.accessoryView = UIImageView(image: image)
-
+        
         return cell
+        
     }
 }
-
 extension FilterTableViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = UIView()
-
+        
         let label: UILabel = {
             let label = UILabel()
             label.font = UIFont.semiBoldM
@@ -83,7 +97,7 @@ extension FilterTableViewController: UITableViewDelegate {
         }()
         
         label.translatesAutoresizingMaskIntoConstraints = false
-
+        
         NSLayoutConstraint.activate([
             label.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
             label.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16)

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -7,8 +7,7 @@
 
 import UIKit
 
-class FilterTableViewController: UIViewController {
-    
+class FilterTableViewController: UIViewController, CustomNaviDelegate {
     private let customView = CustomNaviFilter()
     private let tableView = UITableView()
     
@@ -26,6 +25,8 @@ class FilterTableViewController: UIViewController {
         super.viewDidLoad()
         tableView.dataSource = self
         tableView.delegate = self
+        customView.delegate = self
+        
         customViewLayout()
         tableViewLayout()
     }
@@ -59,6 +60,14 @@ class FilterTableViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0)
         ])
+    }
+    
+    func cancelButtonTapped() {
+        self.dismiss(animated: true)
+    }
+    
+    func saveButtonTapped() {
+        print("dd")
     }
 }
 

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -67,7 +67,7 @@ class FilterTableViewController: UIViewController, CustomNaviDelegate {
     }
     
     func saveButtonTapped() {
-        print("dd")
+        print("저장은 추후 구현")
     }
 }
 

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class FilterTableViewController: UIViewController {
 
     private let tableView = UITableView()
+    private let customView = CustomNaviFilter()
     
     private let sectionKind = ["상태", "담당자", "레이블"]
     private let status = ["열린 이슈", "내가 작성한 이슈", "내가 댓글을 남긴 이슈", "닫힌 이슈"]


### PR DESCRIPTION
## 🔨 작업 내용
커스텀 셀 구현
- [x] 커스텀셀에 해당하는 UI 배치
- [x] 버튼은 클릭시 화면전환을 시켜야 하기 떄문에 델리게이트 구현

커스텀셀을 필터 상단에 배치
- [x] 컨트롤러를 루트뷰로 하여금 필터뷰의 레이아웃을 상단으로 배치
- [x] 하단의 테이블뷰는 커스텀셀을 이용한 배치를 진행

Issue Number: #51 

## 🔑 핵심 키워드
* delegate
* customView

## 🤔 고민했던 부분
* 커스텀뷰가 아닌 네비게이션바로 진행하려고 했지만, 모달형식의 네비게이션바는 받아올 수 없기에 커스텀셀로 진행
* 커스텀뷰를 테이블뷰의 첫 셀에 지정하려 했지만, 스크롤을 내릴 시 위로 올라가버려서 없어질 수 있기 때문에 테이블 뷰 바깥에 구현

## 📝 기타 설명
![Simulator Screen Recording - iPhone 14 Pro - 2023-05-25 at 14 38 41](https://github.com/issue-tracker-team-01/issue-tracker/assets/97685264/b13566e5-e625-416f-b27c-b5d1975cf2e3)

