### PR TITLE
[iOS] 필터테이블뷰 네트워킹 후 화면에 띄우기

### DIFF
--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -65,28 +65,30 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func setupData() {
-        networkManager.performRequest(urlString: PrivateURL.label) { result in
-            switch result {
-            case .success(let assigneeData):
-                self.assigneeArray = assigneeData// 담당자 섹션의 데이터 업데이트
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
+            let group = DispatchGroup()
+            group.enter()
+            networkManager.performRequest(urlString: PrivateURL.label) { result in
+                switch result {
+                case .success(let labelData):
+                    self.labelArray = labelData
+                case .failure(let error):
+                    print(error.localizedDescription)
                 }
-            case .failure(let error):
-                print(error.localizedDescription)
+                group.leave()
             }
-        }
-        networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
-            switch result {
-            case .success(let labelData):
-                self.labelArray = labelData// 담당자 섹션의 데이터 업데이트
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
+            group.enter()
+            networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
+                switch result {
+                case .success(let assigneeData):
+                    self.assigneeArray = assigneeData
+                case .failure(let error):
+                    print(error.localizedDescription)
                 }
-            case .failure(let error):
-                print(error.localizedDescription)
+                group.leave()
             }
-        }
+            group.notify(queue: .main) {
+                self.tableView.reloadData()
+            }
     }
     
     func cancelButtonTapped() {

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
@@ -62,7 +62,7 @@ class IssueCell: UICollectionViewCell {
         return stackView
     }()
     
-    func makeLabel(labels: [Label]) {
+    func makeLabel(labels: [IssueList.Label]) {
         for label in labels {
             var tagLabel: UILabel = {
                 let tags = PaddingLabel(withInsets: 4, 4, 16, 16)

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -96,7 +96,7 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
         cell?.backgroundColor = UIColor.neutralBackground
         
         cell?.titleLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].title
-        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].issueDescription
+        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].description
         //마일스톤
         let attributedString = NSMutableAttributedString(string: "")
         let imageAttachment = NSTextAttachment()

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -14,7 +14,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     let filterViewController = FilterTableViewController()
     
     let networkManager = NetworkManager.shared
-    var issueArrays: [IssueList.Issue] = []
+    var issueArrays: [APIData] = []
     
     var createIssueButton: UIButton = {
         let button = UIButton()
@@ -95,17 +95,17 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
         
         cell?.backgroundColor = UIColor.neutralBackground
         
-        cell?.titleLabel.text = issueArrays[indexPath.row].title
-        cell?.descriptionLabel.text = "두줄까지 가능 ~"
+        cell?.titleLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].title
+        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].issueDescription
         //마일스톤
         let attributedString = NSMutableAttributedString(string: "")
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = UIImage(named: TabBarItems.milestone.rawValue)
         attributedString.append(NSAttributedString(attachment: imageAttachment))
-        attributedString.append(NSAttributedString(string: issueArrays[indexPath.row].milestone ?? String()))
+        attributedString.append(NSAttributedString(string: (issueArrays as? [IssueList.Issue])?[indexPath.row].milestone ?? String()))
         cell?.milestones.attributedText = attributedString
         
-        cell?.makeLabel(labels: issueArrays[indexPath.row].labels)
+        cell?.makeLabel(labels: (issueArrays as? [IssueList.Issue])?[indexPath.row].labels ?? [IssueList.Label]())
         return cell ?? UICollectionViewCell()
     }
     

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -14,7 +14,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     let filterViewController = FilterTableViewController()
     
     let networkManager = NetworkManager.shared
-    var issueArrays: [Issue] = []
+    var issueArrays: [IssueList.Issue] = []
     
     var createIssueButton: UIButton = {
         let button = UIButton()

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -24,12 +24,10 @@ struct IssueList {
     }
 }
 struct LabelList {
-    // MARK: - Welcome10
     struct LabelData {
         let labels: [Label]
     }
     
-    // MARK: - Label
     struct Label {
         let id: Int
         let title, labelDescription, bgColorCode, fontColorCode: String

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -7,17 +7,31 @@
 
 import Foundation
 
-struct IssueData: Codable {
-    let issues: [Issue]
+struct IssueList {
+    struct IssueData: Codable {
+        let issues: [Issue]
+    }
+    
+    struct Label: Codable {
+        let title: String?
+        let bgColorCode: String?
+    }
+    
+    struct Issue: Codable {
+        let title: String?
+        let labels: [Label]
+        let milestone: String?
+    }
 }
-
-struct Label: Codable {
-    let title: String?
-    let bgColorCode: String?
-}
-
-struct Issue: Codable {
-    let title: String?
-    let labels: [Label]
-    let milestone: String?
+struct LabelList {
+    // MARK: - Welcome10
+    struct LabelData {
+        let labels: [Label]
+    }
+    
+    // MARK: - Label
+    struct Label {
+        let id: Int
+        let title, labelDescription, bgColorCode, fontColorCode: String
+    }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+protocol APIData{
+    
+}
+
 struct IssueList {
     struct IssueData: Codable {
         let issues: [Issue]
@@ -17,10 +21,16 @@ struct IssueList {
         let bgColorCode: String?
     }
     
-    struct Issue: Codable {
-        let title: String?
+    struct Count {
+        let label, milestone, opened, closed: Int?
+    }
+    
+    struct Issue: Codable, APIData {
+        let id: Int?
+        let title, issueDescription, createAt: String?
         let labels: [Label]
-        let milestone: String?
+        let milestone, author: String?
+        let authorURL: String?
     }
 }
 struct LabelList {
@@ -28,8 +38,21 @@ struct LabelList {
         let labels: [Label]
     }
     
-    struct Label {
+    struct Label: APIData {
         let id: Int
         let title, labelDescription, bgColorCode, fontColorCode: String
+    }
+}
+
+struct AllAssignee {
+    struct AssigneeData {
+        let assignees: [Assignee]
+    }
+    
+    // MARK: - Assignee
+    struct Assignee: APIData, Codable {
+        let id: Int
+        let name: String
+        let imgURL: String
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -27,32 +27,32 @@ struct IssueList {
     
     struct Issue: Codable, APIData {
         let id: Int?
-        let title, issueDescription, createAt: String?
+        let title, description, createAt: String?
         let labels: [Label]
         let milestone, author: String?
         let authorURL: String?
     }
 }
 struct LabelList {
-    struct LabelData {
+    struct LabelData: Codable {
         let labels: [Label]
     }
     
-    struct Label: APIData {
-        let id: Int
-        let title, labelDescription, bgColorCode, fontColorCode: String
+    struct Label: APIData, Codable {
+        let id: Int?
+        let title, labelDescription, bgColorCode, fontColorCode: String?
     }
 }
 
-struct AllAssignee {
-    struct AssigneeData {
+struct AssigneeList {
+    struct AssigneeData: Codable {
         let assignees: [Assignee]
     }
     
     // MARK: - Assignee
     struct Assignee: APIData, Codable {
-        let id: Int
-        let name: String
-        let imgURL: String
+        let id: Int?
+        let name: String?
+        let imgURL: String?
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -17,7 +17,7 @@ final class NetworkManager {
     
     static let shared = NetworkManager()
     private init() {}
-    typealias NetworkCompletion = (Result<[Issue], NetworkError>) -> Void
+    typealias NetworkCompletion = (Result<[IssueList.Issue], NetworkError>) -> Void
     
     func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
         guard let url = URL(string: urlString) else { return }
@@ -43,9 +43,9 @@ final class NetworkManager {
         task.resume()
     }
     
-    private func parseJSON(_ issueData: Data) -> [Issue]? {
+    private func parseJSON(_ issueData: Data) -> [IssueList.Issue]? {
         do {
-            let issueData = try JSONDecoder().decode(IssueData.self, from: issueData)
+            let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
             return issueData.issues
         } catch {
             print(error.localizedDescription)

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -17,7 +17,7 @@ final class NetworkManager {
     
     static let shared = NetworkManager()
     private init() {}
-    typealias NetworkCompletion = (Result<[IssueList.Issue], NetworkError>) -> Void
+    typealias NetworkCompletion = (Result<[APIData], NetworkError>) -> Void
     
     func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
         guard let url = URL(string: urlString) else { return }
@@ -32,9 +32,9 @@ final class NetworkManager {
                 return
             }
 
-            if let issues = self.parseJSON(safeData) {
+            if let safeData = self.parseJSON(safeData) {
                 print("Parse 실행")
-                completion(.success(issues))
+                completion(.success(safeData))
             } else {
                 print("Parse 실패")
                 completion(.failure(.parseError))
@@ -43,7 +43,7 @@ final class NetworkManager {
         task.resume()
     }
     
-    private func parseJSON(_ issueData: Data) -> [IssueList.Issue]? {
+    private func parseJSON(_ issueData: Data) -> [APIData]? {
         do {
             let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
             return issueData.issues

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -31,7 +31,7 @@ final class NetworkManager {
                 completion(.failure(.dataError))
                 return
             }
-
+            
             if let safeData = self.parseJSON(safeData) {
                 print("Parse 실행")
                 completion(.success(safeData))
@@ -45,8 +45,17 @@ final class NetworkManager {
     
     private func parseJSON(_ issueData: Data) -> [APIData]? {
         do {
-            let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
-            return issueData.issues
+            let decoder = JSONDecoder()
+            
+            if let labelData = try? decoder.decode(LabelList.LabelData.self, from: issueData) {
+                return labelData.labels
+            } else if let assigneeData = try? decoder.decode(AssigneeList.AssigneeData.self, from: issueData) {
+                return assigneeData.assignees
+            } else if let issueData = try? decoder.decode(IssueList.IssueData.self, from: issueData) {
+                return issueData.issues
+            }
+            
+            return nil
         } catch {
             print(error.localizedDescription)
             return nil

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -10,4 +10,5 @@ import Foundation
 struct PrivateURL {
     static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true&assignee=1"
     static let allAssignee = "http://52.79.159.39:8888/api/assignees"
+    static let label = "http://52.79.159.39:8888/api/labels"
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 struct PrivateURL {
-    static let openIssue = "http://52.79.159.39:8888/api/issues?status=open"
+    static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true&assignee=1"
+    static let allAssignee = "http://52.79.159.39:8888/api/assignees"
 }


### PR DESCRIPTION
## 🔨 작업 내용
필터뷰 네트워킹으로 받아오기

- [x] APIData프로토콜 생성및 채택
- [x] NetworkManager 수정
- [x] 네트워크작업시 group과 Notification을 이용해 데이터 받아오기

테이블뷰에 네트워킹 데이터 띄우기

- [x] APIData로 들어갔던 타입들을 타입캐스팅하여 프로퍼티에 접근
- [x] section에따라 데이터 구분

Issue Number: #112 

## 🔑 핵심 키워드
* group
* notification

## 🤔 고민했던 부분
* 네트워킹을 다중으로 하는 방법 (DTO를 따로 설정해야하는가?) (같은 형식이 아니라면 따로설정해야함 >> 해결 !)
* 데이터를 받아왔음에도 테이블뷰 화면에 나타나질 않음 >> 비동기작업이라 group화시켜서 reloadData해줘야함 (해결!)

## 📝 기타 설명
* 하림 칭찬해주세요 ! 제가 해냈어요 !
![Simulator Screen Recording - iPhone 14 Pro - 2023-05-31 at 01 23 00](https://github.com/issue-tracker-team-01/issue-tracker/assets/97685264/5c3c3c55-2c7c-4a23-91ae-25c2fab3cea0)
